### PR TITLE
完了したタスクを一括で削除する機能を実装

### DIFF
--- a/app/(tabs)/todo.tsx
+++ b/app/(tabs)/todo.tsx
@@ -8,6 +8,7 @@ import {
   StyleSheet,
   TouchableOpacity,
   Pressable,
+  Alert,
 } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
@@ -70,6 +71,37 @@ const TodoScreen = () => {
     setTasks((prevTasks) => prevTasks.filter((task) => task.id !== id));
   };
 
+  const handleClearCompleted = () => {
+    const deleteLists = tasks.filter((task) => task.isCompleted);
+
+    if(deleteLists.length === 0) {
+      Alert.alert("情報", "削除するタスクがありません");
+      return;
+    }
+
+    Alert.alert(
+      "確認",
+      "削除を実行してよろしいですか？",
+      [
+        {
+          text: "キャンセル",
+          style: "cancel",
+        },
+        {
+          text: "削除する",
+          style: "destructive",
+          onPress: () => {
+            setTasks((prevTasks) =>
+              prevTasks.filter((task) => !task.isCompleted)
+            );
+            Alert.alert("削除完了", "完了したタスクを削除しました");
+          },
+        },
+      ],
+      { cancelable: true }
+    );
+  };
+
   const toggleTaskCompletion = async (id: number) => {
     setTasks((prevTasks) => {
       return prevTasks.map((task) =>
@@ -96,6 +128,13 @@ const TodoScreen = () => {
         <Button
           title={hideCompleted ? "完了タスクを表示" : "完了タスクを非表示"}
           onPress={() => setHideCompleted((prev) => !prev)}
+        />
+      </View>
+
+      <View style={styles.clearContainer}>
+        <Button
+          title="完了したタスクを全て削除"
+          onPress={handleClearCompleted}
         />
       </View>
 
@@ -142,7 +181,7 @@ const TodoScreen = () => {
         rightOpenValue={-75}
       />
     </View>
-  )
+  );
 };
 
 const styles = StyleSheet.create({
@@ -205,7 +244,11 @@ const styles = StyleSheet.create({
   toggleContainer: {
     marginBottom: 10,
     alignItems: "flex-end",
-  }
+  },
+  clearContainer: {
+    marginBottom: 10,
+    alignItems: "flex-end",
+  },
 });
 
 export default TodoScreen;


### PR DESCRIPTION
## 概要
完了済み（チェック）のタスクをまとめて削除するためのボタンを追加しました
Close #10 

## 内容
-「 完了したタスクを削除」のボタンを追加
- `filter()`を使って`isCompleted === true`のみを取り除くロジックで実装
- `Alert`を使用し、ユーザーが削除を確認した場合のみ実行
- 削除対象の完了タスクが1件もない場合は、削除せずに「完了するタスクがありません」と表示

## 動作確認
- ボタンを押すと、完了済みのタスクのみが全て削除され、未完了のタスクはそのまま残る
- 削除対象がない場合にはアラートで通知され、削除は行われない
