### PR TITLE
fixed: タスクに期限を設けて、期限順にソートするように実装

### DIFF
--- a/components/TaskItem.tsx
+++ b/components/TaskItem.tsx
@@ -1,0 +1,65 @@
+import { Pressable, StyleSheet, Text } from "react-native";
+import { getDueDateStatus } from "@/lib/getDueDateStatus";
+
+type Props = {
+  item: {
+    id: number;
+    list: string;
+    isCompleted: boolean;
+    dueDate?: string | null;
+  };
+  onToggle: (id: number) => void;
+};
+
+const TaskItem = ({ item, onToggle }: Props) => {
+  const status = getDueDateStatus(item.dueDate);
+  return (
+    <Pressable
+      onPress={() => onToggle(item.id)}
+      style={({ pressed }) => [styles.taskItem, { opacity: 1 }]}
+    >
+      <Text style={[styles.taskText, item.isCompleted && styles.completedText]}>
+        {item.list}
+      </Text>
+      <Text
+        style={[
+          styles.dueText,
+          status === "today" && styles.dueToday,
+          status === "overdue" && styles.dueOverdue,
+        ]}
+      >
+        期限: {item.dueDate ?? "未設定"}
+      </Text>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  taskItem: {
+    padding: 15,
+    backgroundColor: "#eee",
+    borderRadius: 5,
+    marginBottom: 10,
+  },
+  taskText: {
+    fontSize: 16,
+  },
+  completedText: {
+    textDecorationLine: "line-through",
+    color: "#9f9595",
+  },
+  dueText: {
+    fontSize: 12,
+    color: "#888",
+  },
+  dueToday: {
+    color: "#f39c12",
+    fontWeight: "bold",
+  },
+  dueOverdue: {
+    color: "#e74c3c",
+    fontWeight: "bold",
+  },
+});
+
+export default TaskItem;

--- a/lib/getDueDateStatus.ts
+++ b/lib/getDueDateStatus.ts
@@ -1,0 +1,13 @@
+export const getDueDateStatus = (dueDateStr?: string | null) => {
+  if(!dueDateStr) return "none";
+
+  const today = new Date();
+  const dueDate = new Date(dueDateStr);
+
+  const todayStr = today.toISOString().split("T")[0];
+  const dueStr = dueDate.toISOString().split("T")[0];
+
+  if(dueStr === todayStr) return "today";
+  if(dueStr < todayStr) return "overdue";
+  return "future";
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,0 +1,25 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { TaskState } from "../types/task";
+
+const loadTasks = async (): Promise<TaskState[]> => {
+  try {
+    const json = await AsyncStorage.getItem("TASKS");
+    return json ? JSON.parse(json) : [];
+  } catch(e) {
+    console.error("データを取得できませんでした", e);
+    return [];
+  }
+}
+
+const saveTasks = async (tasks: TaskState[]) => {
+  try {
+    const json = JSON.stringify(tasks);
+    await AsyncStorage.setItem("TASKS", json)
+  } catch(e) {
+    console.error("データを保存できませんでした", e);
+  }
+}
+
+export { loadTasks, saveTasks };
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
         "@react-native-async-storage/async-storage": "^2.2.0",
+        "@react-native-community/datetimepicker": "8.3.0",
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
@@ -2810,6 +2811,29 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-community/datetimepicker": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.3.0.tgz",
+      "integrity": "sha512-K/KgaJbLtjMpx4PaG4efrVIcSe6+DbLufeX1lwPB5YY8i3sq9dOh6WcAcMTLbaRTUpurebQTkl7puHPFm9GalA==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": ">=50.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-windows": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "react-native-screens": "~4.11.1",
     "react-native-swipe-list-view": "^3.2.9",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "@react-native-community/datetimepicker": "8.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/types/task.ts
+++ b/types/task.ts
@@ -1,0 +1,6 @@
+export type TaskState = {
+  id: number;
+  list: string;
+  isCompleted: boolean;
+  dueDate?: string | null;
+}


### PR DESCRIPTION
## 概要

- 各タスクに期限を設定できるようにする
- タスクは期限が近い順にソートする
- 期限はタスク一覧に表示される
- 期限が当日・過ぎているタスクを色分けして強調表示する

Close #14 

---

## 内容

- `DateTimePicker`を使用して、ボタンを押すとカレンダーを表示して日付を選択できるようにしました
- `addTasks`にdueDateを追加して、期限付きのタスク登録に対応
- 常時ように`sortedTasks`を導入し、期限が近い順にソート
- `getDueDateStatus()`によって以下のように期限ステートを色分け
   - 今日が期限 → オレンジ
   - 期限切れ → 赤
   - 未設定 → 表示なし or ラベル「未設定」

---

## 動作確認

- 「日付を選択する」を押すとカレンダーが表示される
- 日付を選択してタスクを追加すると、期限付きで表示される
- 日付を選択しない時には、タスクに「未設定」と表示される
- タスクが日付の近い順に表示され、未設定のものは順番が一番下に並ぶ
- 期限が当日・期限切れのタスクが強調表示される

---
 
## 備考

- コード量が多くなってきましたので、components,lib,typesに分けて可動性をよくしました
- 確認をしていただき、問題がなければマージをお願いします